### PR TITLE
Remove unnecessary ANativeWindow_SetBuffersGeometry() call.

### DIFF
--- a/jni/ndk_helper/GLContext.cpp
+++ b/jni/ndk_helper/GLContext.cpp
@@ -142,14 +142,6 @@ bool GLContext::InitEGLSurface() {
   eglQuerySurface(display_, surface_, EGL_WIDTH, &screen_width_);
   eglQuerySurface(display_, surface_, EGL_HEIGHT, &screen_height_);
 
-  /* EGL_NATIVE_VISUAL_ID is an attribute of the EGLConfig that is
-   * guaranteed to be accepted by ANativeWindow_setBuffersGeometry().
-   * As soon as we picked a EGLConfig, we can safely reconfigure the
-   * ANativeWindow buffers to match, using EGL_NATIVE_VISUAL_ID. */
-  EGLint format;
-  eglGetConfigAttrib(display_, config_, EGL_NATIVE_VISUAL_ID, &format);
-  ANativeWindow_setBuffersGeometry(window_, 0, 0, format);
-
   return true;
 }
 


### PR DESCRIPTION
- We don't have to call the API unless want to have different buffer size than
  the native resolution.
- This was causing broken rendering on some devices.
